### PR TITLE
sched-ext: introduce the concept of performance profiles

### DIFF
--- a/src/schedext-window.hpp
+++ b/src/schedext-window.hpp
@@ -66,6 +66,7 @@ class SchedExtWindow final : public QMainWindow {
  private:
     void on_apply() noexcept;
     void on_disable() noexcept;
+    void on_sched_changed() noexcept;
 
     std::vector<std::string> m_previously_set_options{};
     std::unique_ptr<Ui::SchedExtWindow> m_ui = std::make_unique<Ui::SchedExtWindow>();

--- a/src/schedext-window.ui
+++ b/src/schedext-window.ui
@@ -86,6 +86,16 @@
       <item row="1" column="3">
        <widget class="QComboBox" name="schedext_combo_box"/>
       </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="scheduler_profile_select_label">
+        <property name="text">
+         <string> Select scheduler profile:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QComboBox" name="schedext_profile_combo_box"/>
+      </item>
       <item row="0" column="0">
        <spacer name="horizontalSpacer_6">
         <property name="orientation">
@@ -106,14 +116,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="scheduler_set_flags_label">
         <property name="text">
-         <string>Set sched-ext scheduler flags:</string>
+         <string>Set sched-ext extra scheduler flags:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="3">
+      <item row="3" column="3">
        <widget class="QLineEdit" name="schedext_flags_edit"/>
       </item>
      </layout>


### PR DESCRIPTION
Add an extra combo box to select the "performance profile" for the currently selected sched-ext scheduler. The selected profile will be automatically converted into the appropriate flags for the chosen scheduler.

Currently, only scx_bpfland and scx_lavd are supported, so the additional combo box will be visible only when one of these schedulers is selected.