### PR TITLE
sched_ext: drop -c 0 from the gaming preset with scx_bpfland

### DIFF
--- a/src/schedext-window.cpp
+++ b/src/schedext-window.cpp
@@ -127,7 +127,7 @@ constexpr auto get_scx_flags(std::string_view scx_sched, SchedMode scx_mode) noe
     if (scx_mode == SchedMode::Auto) {
     } else if (scx_mode == SchedMode::Gaming) {
         if (scx_sched == "scx_bpfland"sv) {
-            return "-c 0 -k -m performance"sv;
+            return "-k -m performance"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }


### PR DESCRIPTION
Running bpfland with `-c 0` can lead to stuttery behavior if multiple worklodas are running in a system at the same time.

Since this option offers minimal benefits for gaming and is only effective when a *single* application is running, it's just safer to avoid using it in the gaming profile.