### PR TITLE
Bump to 1.11.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 ## name and version
 ##
 project(cachyos-kernel-manager
-        VERSION 1.10.1
+        VERSION 1.11.0
         LANGUAGES CXX)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(CPM)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
-find_package(Qt6 COMPONENTS Widgets LinguistTools Concurrent REQUIRED)
+find_package(Qt6 COMPONENTS Widgets LinguistTools Concurrent DBus REQUIRED)
 pkg_check_modules(
   LIBALPM
   REQUIRED
@@ -119,6 +119,7 @@ qt_add_executable(${PROJECT_NAME}
     "${CMAKE_BINARY_DIR}/compile_options.hpp"
     src/config-options.hpp src/config-options.cpp
     src/conf-window.hpp src/conf-window.cpp
+    src/scx_utils.hpp src/scx_utils.cpp
     src/schedext-window.hpp src/schedext-window.cpp
     src/conf-patches-page.hpp src/conf-patches-page.ui
     src/conf-options-page.hpp src/conf-options-page.ui
@@ -142,7 +143,7 @@ include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR})
 corrosion_import_crate(MANIFEST_PATH "config-option-lib/Cargo.toml" FLAGS "${CARGO_FLAGS}")
 corrosion_add_cxxbridge(config-option-lib-cxxbridge CRATE config_option_lib MANIFEST_PATH "config-option-lib/Cargo.toml" FILES lib.rs)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE project_warnings project_options Qt6::Widgets Qt6::Concurrent Threads::Threads fmt::fmt frozen::frozen config-option-lib-cxxbridge PkgConfig::LIBALPM PkgConfig::LIBGLIB)
+target_link_libraries(${PROJECT_NAME} PRIVATE project_warnings project_options Qt6::Widgets Qt6::Concurrent Qt6::DBus Threads::Threads fmt::fmt frozen::frozen config-option-lib-cxxbridge PkgConfig::LIBALPM PkgConfig::LIBGLIB)
 
 option(ENABLE_UNITY "Enable Unity builds of projects" OFF)
 if(ENABLE_UNITY)

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cachyos-kernel-manager', 'cpp',
-        version: '1.10.1',
+        version: '1.11.0',
         license: 'GPLv3',
         meson_version: '>=0.59.0',
         default_options: ['cpp_std=c++20',

--- a/src/schedext-window.cpp
+++ b/src/schedext-window.cpp
@@ -19,11 +19,13 @@
 // NOLINTBEGIN(bugprone-unhandled-exception-at-new)
 
 #include "schedext-window.hpp"
+#include "scx_utils.hpp"
 #include "utils.hpp"
 
 #include <fstream>
 #include <string>
 #include <string_view>
+#include <thread>
 
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -38,6 +40,7 @@
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
 
+#include <QMessageBox>
 #include <QProcess>
 #include <QStringList>
 
@@ -83,61 +86,50 @@ auto get_current_scheduler() noexcept -> std::string {
     return current_sched;
 }
 
-auto is_scx_service_enabled() noexcept -> bool {
+auto is_scx_loader_service_enabled() noexcept -> bool {
     using namespace std::string_view_literals;
-    return utils::exec("systemctl is-enabled scx"sv) == "enabled"sv;
+    return utils::exec("systemctl is-enabled scx_loader"sv) == "enabled"sv;
 }
 
-auto is_scx_service_active() noexcept -> bool {
+auto is_scx_loader_service_active() noexcept -> bool {
     using namespace std::string_view_literals;
-    return utils::exec("systemctl is-active scx"sv) == "active"sv;
+    return utils::exec("systemctl is-active scx_loader"sv) == "active"sv;
 }
 
-enum class SchedMode : std::uint8_t {
-    /// Default values for the scheduler
-    Auto = 0,
-    /// Applies flags for better gaming experience
-    Gaming = 1,
-    /// Applies flags for lower power usage
-    PowerSave = 2,
-    /// Starts scheduler in low latency mode
-    LowLatency = 3,
-};
-
-constexpr auto get_scx_mode_from_str(std::string_view scx_mode) noexcept -> SchedMode {
+constexpr auto get_scx_mode_from_str(std::string_view scx_mode) noexcept -> scx::SchedMode {
     using namespace std::string_view_literals;
 
     if (scx_mode == "gaming"sv) {
-        return SchedMode::Gaming;
+        return scx::SchedMode::Gaming;
     } else if (scx_mode == "lowlatency"sv) {
-        return SchedMode::LowLatency;
+        return scx::SchedMode::LowLatency;
     } else if (scx_mode == "powersave"sv) {
-        return SchedMode::PowerSave;
+        return scx::SchedMode::PowerSave;
     }
-    return SchedMode::Auto;
+    return scx::SchedMode::Auto;
 }
 
-constexpr auto get_scx_flags(std::string_view scx_sched, SchedMode scx_mode) noexcept -> std::string_view {
+constexpr auto get_scx_flags(std::string_view scx_sched, scx::SchedMode scx_mode) noexcept -> std::string_view {
     using namespace std::string_view_literals;
 
     // Map the selected performance profile to the different scheduler
     // options.
     //
     // NOTE: only scx_bpfland and scx_lavd are supported for now.
-    if (scx_mode == SchedMode::Auto) {
-    } else if (scx_mode == SchedMode::Gaming) {
+    if (scx_mode == scx::SchedMode::Auto) {
+    } else if (scx_mode == scx::SchedMode::Gaming) {
         if (scx_sched == "scx_bpfland"sv) {
             return "-k -m performance"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }
-    } else if (scx_mode == SchedMode::LowLatency) {
+    } else if (scx_mode == scx::SchedMode::LowLatency) {
         if (scx_sched == "scx_bpfland"sv) {
             return "--lowlatency"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }
-    } else if (scx_mode == SchedMode::PowerSave) {
+    } else if (scx_mode == scx::SchedMode::PowerSave) {
         if (scx_sched == "scx_bpfland"sv) {
             return "-m powersave"sv;
         } else if (scx_sched == "scx_lavd"sv) {
@@ -157,19 +149,22 @@ SchedExtWindow::SchedExtWindow(QWidget* parent)
     setWindowFlags(Qt::Window);  // for the close, min and max buttons
 
     // Selecting the scheduler
-    QStringList sched_names;
-    sched_names << "scx_bpfland"
-                << "scx_central"
-                << "scx_lavd"
-                << "scx_layered"
-                << "scx_nest"
-                << "scx_qmap"
-                << "scx_rlfifo"
-                << "scx_rustland"
-                << "scx_rusty"
-                << "scx_simple"
-                << "scx_userland";
-    m_ui->schedext_combo_box->addItems(sched_names);
+    auto supported_scheds = scx::loader::get_supported_scheds();
+    if (supported_scheds.has_value()) {
+        m_ui->schedext_combo_box->addItems(*supported_scheds);
+    } else {
+        QMessageBox::critical(this, "CachyOS Kernel Manager", tr("Cannot get information from scx_loader!\nIs it working?\nThis is needed for the app to work properly"));
+
+        // hide all components which depends on scheduler management
+        m_ui->schedext_combo_box->setHidden(true);
+        m_ui->scheduler_select_label->setHidden(true);
+
+        m_ui->schedext_profile_combo_box->setHidden(true);
+        m_ui->scheduler_profile_select_label->setHidden(true);
+
+        m_ui->schedext_flags_edit->setHidden(true);
+        m_ui->scheduler_set_flags_label->setHidden(true);
+    }
 
     // Selecting the performance profile
     QStringList sched_profiles;
@@ -213,11 +208,11 @@ void SchedExtWindow::on_disable() noexcept {
 
     using namespace std::string_view_literals;
     // TODO(vnepogodin): refactor that
-    if (is_scx_service_enabled()) {
-        QProcess::startDetached("/usr/bin/pkexec", {"/usr/bin/systemctl", "disable", "--now", "scx"});
+    if (is_scx_loader_service_enabled()) {
+        QProcess::startDetached("/usr/bin/pkexec", {"/usr/bin/systemctl", "disable", "--now", "scx_loader"});
         fmt::print("Disabling scx\n");
-    } else if (is_scx_service_active()) {
-        QProcess::startDetached("/usr/bin/pkexec", {"/usr/bin/systemctl", "stop", "scx"});
+    } else if (is_scx_loader_service_active()) {
+        QProcess::startDetached("/usr/bin/pkexec", {"/usr/bin/systemctl", "stop", "scx_loader"});
         fmt::print("Stoping scx\n");
     }
 
@@ -245,33 +240,36 @@ void SchedExtWindow::on_apply() noexcept {
     m_ui->disable_button->setEnabled(false);
     m_ui->apply_button->setEnabled(false);
 
-    const auto service_cmd = []() -> std::string_view {
-        using namespace std::string_view_literals;
-        if (!is_scx_service_enabled()) {
-            return "enable --now"sv;
-        }
-        return "restart"sv;
-    }();
-
-    static constexpr auto get_scx_flags_sed = [](std::string_view scx_sched,
-                                                  SchedMode scx_mode,
-                                                  std::string_view scx_extra_flags) -> std::string {
-        const auto scx_base_flags = get_scx_flags(scx_sched, scx_mode);
-        return fmt::format(R"(-e 's/^\s*#\?\s*SCX_FLAGS=.*$/SCX_FLAGS="{} {}"/')", scx_base_flags, scx_extra_flags);
-    };
-
     // TODO(vnepogodin): refactor that
     const auto& current_selected = m_ui->schedext_combo_box->currentText().toStdString();
     const auto& current_profile  = m_ui->schedext_profile_combo_box->currentText().toStdString();
     const auto& extra_flags      = m_ui->schedext_flags_edit->text().trimmed().toStdString();
 
-    const auto& scx_mode      = get_scx_mode_from_str(current_profile);
-    const auto& scx_flags_sed = get_scx_flags_sed(current_selected, scx_mode, extra_flags);
+    const auto& scx_mode = get_scx_mode_from_str(current_profile);
 
-    const auto& sed_cmd = fmt::format("sed -e 's/SCX_SCHEDULER=.*/SCX_SCHEDULER={}/' {} -i /etc/default/scx && systemctl {} scx", current_selected, scx_flags_sed, service_cmd);
+    auto sched_args = QStringList();
+    {
+        const auto scx_base_flags = get_scx_flags(current_selected, scx_mode);
+        if (!scx_base_flags.empty()) {
+            sched_args << QString::fromStdString(std::string{scx_base_flags}).split(' ');
+        }
+    }
+    if (!extra_flags.empty()) {
+        sched_args << QString::fromStdString(extra_flags).split(' ');
+    }
 
-    QProcess::startDetached("/usr/bin/pkexec", {"/usr/bin/bash", "-c", QString::fromStdString(sed_cmd)});
-    fmt::print("Applying scx {}\n", current_selected);
+    fmt::print("Applying scx '{}' with args: {}\n", current_selected, sched_args.join(' ').toStdString());
+    auto sched_reply = scx::loader::switch_scheduler_with_args(current_selected, sched_args);
+    if (!sched_reply) {
+        qDebug() << "Failed to switch '" << current_selected << "' with args:" << sched_args;
+    }
+
+    // NOTE: with the current setup it doesn't make any sense, but in future the loader saves information about scx setup(scx and mode/flags).
+    // also the scx_loader replace scx.service in the sense that it will pre-start using saved information
+    if (!is_scx_loader_service_enabled()) {
+        fmt::print("Enabling scx_loader service\n");
+        QProcess::startDetached("/usr/bin/pkexec", {"/usr/bin/systemctl", "enable", "scx_loader"});
+    }
 
     m_ui->disable_button->setEnabled(true);
     m_ui->apply_button->setEnabled(true);

--- a/src/schedext-window.cpp
+++ b/src/schedext-window.cpp
@@ -119,13 +119,13 @@ constexpr auto get_scx_flags(std::string_view scx_sched, scx::SchedMode scx_mode
     if (scx_mode == scx::SchedMode::Auto) {
     } else if (scx_mode == scx::SchedMode::Gaming) {
         if (scx_sched == "scx_bpfland"sv) {
-            return "-k -m performance"sv;
+            return "-m performance"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }
     } else if (scx_mode == scx::SchedMode::LowLatency) {
         if (scx_sched == "scx_bpfland"sv) {
-            return "--lowlatency"sv;
+            return "-k -s 5000 -l 5000"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }

--- a/src/scx_utils.cpp
+++ b/src/scx_utils.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) 2024 Vladislav Nepogodin
+//
+// This file is part of CachyOS kernel manager.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "scx_utils.hpp"
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusVariant>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#include <fmt/core.h>
+
+namespace scx::loader {
+
+auto get_supported_scheds() noexcept -> std::optional<QStringList> {
+    QDBusMessage message = QDBusMessage::createMethodCall(
+        "org.scx.Loader",
+        "/org/scx/Loader",
+        "org.freedesktop.DBus.Properties",
+        "Get");
+    message << "org.scx.Loader" << "SupportedSchedulers";
+    QDBusMessage reply = QDBusConnection::systemBus().call(message);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        fmt::print(stderr, "Failed to get supported schedulers: {}\n", reply.errorMessage().toStdString());
+        return std::nullopt;
+    }
+
+    return reply.arguments().at(0).value<QDBusVariant>().variant().toStringList();
+}
+
+auto get_current_scheduler() noexcept -> std::optional<QString> {
+    QDBusMessage message = QDBusMessage::createMethodCall(
+        "org.scx.Loader",
+        "/org/scx/Loader",
+        "org.freedesktop.DBus.Properties",
+        "Get");
+    message << "org.scx.Loader" << "CurrentScheduler";
+    QDBusMessage reply = QDBusConnection::systemBus().call(message);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        fmt::print(stderr, "Failed to get current scheduler: {}\n", reply.errorMessage().toStdString());
+        return std::nullopt;
+    }
+
+    return reply.arguments().at(0).value<QDBusVariant>().variant().toString();
+}
+
+auto switch_scheduler_with_args(std::string_view scx_sched, QStringList sched_args) noexcept -> bool {
+    QDBusMessage message = QDBusMessage::createMethodCall(
+        "org.scx.Loader",
+        "/org/scx/Loader",
+        "org.scx.Loader",
+        "SwitchSchedulerWithArgs");
+    message << QString::fromStdString(std::string{scx_sched}) << sched_args;
+    QDBusMessage reply = QDBusConnection::systemBus().call(message);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        fmt::print(stderr, "Failed to switch scheduler with args: {}\n", reply.errorMessage().toStdString());
+        return false;
+    }
+    return true;
+}
+
+}  // namespace scx::loader

--- a/src/scx_utils.hpp
+++ b/src/scx_utils.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2024 Vladislav Nepogodin
+//
+// This file is part of CachyOS kernel manager.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#ifndef SCX_UTILS_HPP
+#define SCX_UTILS_HPP
+
+#include <optional>
+#include <string_view>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+
+#include <QStringList>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace scx {
+
+enum class SchedMode : std::uint8_t {
+    /// Default values for the scheduler
+    Auto = 0,
+    /// Applies flags for better gaming experience
+    Gaming = 1,
+    /// Applies flags for lower power usage
+    PowerSave = 2,
+    /// Starts scheduler in low latency mode
+    LowLatency = 3,
+};
+
+}  // namespace scx
+
+namespace scx::loader {
+
+// Gets supported schedulers by scx_loader
+auto get_supported_scheds() noexcept -> std::optional<QStringList>;
+
+// Gets currently running scheduler by scx_loader
+auto get_current_scheduler() noexcept -> std::optional<QString>;
+
+// Switches scheduler with specified args
+auto switch_scheduler_with_args(std::string_view scx_sched, QStringList sched_args) noexcept -> bool;
+
+}  // namespace scx::loader
+
+#endif  // SCX_UTILS_HPP


### PR DESCRIPTION
A new scx-scheds has been released and the kernel manager needs changes so that users can handle it properly. It's also time to enable default scx_loader support