### PR TITLE
kernel manager: sync default flags with scx-scheds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 ## name and version
 ##
 project(cachyos-kernel-manager
-        VERSION 1.10.1
+        VERSION 1.10.2
         LANGUAGES CXX)
 
 

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('cachyos-kernel-manager', 'cpp',
-        version: '1.10.1',
+        version: '1.10.2',
         license: 'GPLv3',
         meson_version: '>=0.59.0',
         default_options: ['cpp_std=c++20',

--- a/src/schedext-window.cpp
+++ b/src/schedext-window.cpp
@@ -127,13 +127,13 @@ constexpr auto get_scx_flags(std::string_view scx_sched, SchedMode scx_mode) noe
     if (scx_mode == SchedMode::Auto) {
     } else if (scx_mode == SchedMode::Gaming) {
         if (scx_sched == "scx_bpfland"sv) {
-            return "-k -m performance"sv;
+            return "-m performance"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }
     } else if (scx_mode == SchedMode::LowLatency) {
         if (scx_sched == "scx_bpfland"sv) {
-            return "--lowlatency"sv;
+            return "-k -s 5000 -l 5000"sv;
         } else if (scx_sched == "scx_lavd"sv) {
             return "--performance"sv;
         }


### PR DESCRIPTION
bpfland has dropped the lowlatency flag https://github.com/sched-ext/scx/commit/78101e46883674ed294a31f5af586e9e592f7673 and changed the suggested flags https://github.com/sched-ext/scx/commit/191cc7fe8b76f568b017b9d62fe65a3763a1bbd3 - so let's apply them to the kernel manager.