### PR TITLE
👷 scx: use scx_loader to start/stop scheds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(CPM)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 find_package(Threads REQUIRED)
 find_package(PkgConfig REQUIRED)
-find_package(Qt6 COMPONENTS Widgets LinguistTools Concurrent REQUIRED)
+find_package(Qt6 COMPONENTS Widgets LinguistTools Concurrent DBus REQUIRED)
 pkg_check_modules(
   LIBALPM
   REQUIRED
@@ -119,6 +119,7 @@ qt_add_executable(${PROJECT_NAME}
     "${CMAKE_BINARY_DIR}/compile_options.hpp"
     src/config-options.hpp src/config-options.cpp
     src/conf-window.hpp src/conf-window.cpp
+    src/scx_utils.hpp src/scx_utils.cpp
     src/schedext-window.hpp src/schedext-window.cpp
     src/conf-patches-page.hpp src/conf-patches-page.ui
     src/conf-options-page.hpp src/conf-options-page.ui
@@ -140,9 +141,9 @@ enable_sanitizers(project_options)
 include_directories(${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR})
 
 corrosion_import_crate(MANIFEST_PATH "config-option-lib/Cargo.toml" FLAGS "${CARGO_FLAGS}")
-corrosion_add_cxxbridge(config-option-lib-cxxbridge CRATE config_option_lib MANIFEST_PATH "config-option-lib/Cargo.toml" FILES lib.rs)
+corrosion_add_cxxbridge(config-option-lib-cxxbridge CRATE config_option_lib MANIFEST_PATH "config-option-lib/Cargo.toml" FILES lib.rs scx_loader_config.rs)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE project_warnings project_options Qt6::Widgets Qt6::Concurrent Threads::Threads fmt::fmt frozen::frozen config-option-lib-cxxbridge PkgConfig::LIBALPM PkgConfig::LIBGLIB)
+target_link_libraries(${PROJECT_NAME} PRIVATE project_warnings project_options Qt6::Widgets Qt6::Concurrent Qt6::DBus Threads::Threads fmt::fmt frozen::frozen config-option-lib-cxxbridge PkgConfig::LIBALPM PkgConfig::LIBGLIB)
 
 option(ENABLE_UNITY "Enable Unity builds of projects" OFF)
 if(ENABLE_UNITY)

--- a/config-option-lib/src/lib.rs
+++ b/config-option-lib/src/lib.rs
@@ -14,6 +14,8 @@
 // with this program; if not, write to the Free Software Foundation, Inc.,
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+pub mod scx_loader_config;
+
 use std::fs;
 use std::io::Write;
 

--- a/config-option-lib/src/scx_loader_config.rs
+++ b/config-option-lib/src/scx_loader_config.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-2.0
+//
+// Copyright (c) 2024 Vladislav Nepogodin <vnepogodin@cachyos.org>
+
+// This software may be used and distributed according to the terms of the
+// GNU General Public License version 2.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[cxx::bridge(namespace = "scx_loader")]
+mod ffi {
+    extern "Rust" {
+        type Config;
+
+        /// Initialize config from config path, if the file doesn't exist config with default values
+        /// will be created.
+        fn init_config_file(config_path: &str) -> Result<Box<Config>>;
+
+        /// Write the config to the file.
+        fn write_config_file(&self, filepath: &str) -> Result<()>;
+
+        /// Retrieves default scheduler if set, overwise returns Err
+        fn get_default_scheduler(&self) -> Result<String>;
+
+        /// Retrieves default mode if set, overwise returns Auto
+        fn get_default_mode(&self) -> u32;
+
+        /// Get the scx flags for the given sched mode
+        fn get_scx_flags_for_mode(
+            &self,
+            supported_sched: &str,
+            sched_mode: u32,
+        ) -> Result<Vec<String>>;
+
+        /// Set the default scheduler with default mode
+        fn set_scx_sched_with_mode(&mut self, supported_sched: &str, sched_mode: u32)
+            -> Result<()>;
+    }
+}
+
+// TODO(vnepogodin): instead of copying code from scx_loader, the scx_loader should be crate with
+// provided functions and traits which we call here
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SupportedSched {
+    #[serde(rename = "scx_bpfland")]
+    Bpfland,
+    #[serde(rename = "scx_rusty")]
+    Rusty,
+    #[serde(rename = "scx_lavd")]
+    Lavd,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum SchedMode {
+    /// Default values for the scheduler
+    Auto = 0,
+    /// Applies flags for better gaming experience
+    Gaming = 1,
+    /// Applies flags for lower power usage
+    PowerSave = 2,
+    /// Starts scheduler in low latency mode
+    LowLatency = 3,
+}
+
+impl TryFrom<u32> for SchedMode {
+    type Error = anyhow::Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        match value {
+            0 => Ok(SchedMode::Auto),
+            1 => Ok(SchedMode::Gaming),
+            2 => Ok(SchedMode::PowerSave),
+            3 => Ok(SchedMode::LowLatency),
+            _ => anyhow::bail!("SchedMode with such value doesn't exist"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Config {
+    pub default_sched: Option<SupportedSched>,
+    pub default_mode: Option<SchedMode>,
+    pub scheds: HashMap<String, Sched>,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct Sched {
+    pub auto_mode: Option<Vec<String>>,
+    pub gaming_mode: Option<Vec<String>>,
+    pub lowlatency_mode: Option<Vec<String>>,
+    pub powersave_mode: Option<Vec<String>>,
+}
+
+fn init_config_file(config_path: &str) -> Result<Box<Config>> {
+    let config = init_config(config_path).context("Failed to initialize config")?;
+    Ok(Box::new(config))
+}
+
+impl Config {
+    fn write_config_file(&self, filepath: &str) -> Result<()> {
+        let toml_content = toml::to_string(self)?;
+
+        let mut file_obj = fs::File::create(filepath)?;
+        file_obj.write_all(toml_content.as_bytes())?;
+
+        Ok(())
+    }
+
+    fn get_default_scheduler(&self) -> Result<String> {
+        if let Some(default_sched) = &self.default_sched {
+            Ok(get_name_from_scx(default_sched).to_owned())
+        } else {
+            anyhow::bail!("Default scheduler is not set")
+        }
+    }
+
+    fn get_default_mode(&self) -> u32 {
+        if let Some(sched_mode) = &self.default_mode {
+            sched_mode.clone() as u32
+        } else {
+            SchedMode::Auto as u32
+        }
+    }
+
+    fn get_scx_flags_for_mode(
+        &self,
+        supported_sched: &str,
+        sched_mode: u32,
+    ) -> Result<Vec<String>> {
+        let scx_sched = get_scx_from_str(supported_sched)?;
+        let sched_mode: SchedMode = sched_mode.try_into()?;
+        let args = get_scx_flags_for_mode(self, &scx_sched, sched_mode);
+        Ok(args)
+    }
+
+    fn set_scx_sched_with_mode(&mut self, supported_sched: &str, sched_mode: u32) -> Result<()> {
+        let scx_sched = get_scx_from_str(supported_sched)?;
+        let sched_mode: SchedMode = sched_mode.try_into()?;
+
+        self.default_sched = Some(scx_sched);
+        self.default_mode = Some(sched_mode);
+
+        Ok(())
+    }
+}
+
+/// Initialize config from first found config path, overwise fallback to default config
+pub fn init_config(config_path: &str) -> Result<Config> {
+    if Path::new(config_path).exists() {
+        parse_config_file(config_path)
+    } else {
+        Ok(get_default_config())
+    }
+}
+
+pub fn parse_config_file(filepath: &str) -> Result<Config> {
+    let file_content = fs::read_to_string(filepath)?;
+    parse_config_content(&file_content)
+}
+
+fn parse_config_content(file_content: &str) -> Result<Config> {
+    if file_content.is_empty() {
+        anyhow::bail!("The config file is empty!")
+    }
+    let config: Config = toml::from_str(file_content)?;
+    Ok(config)
+}
+
+pub fn get_default_config() -> Config {
+    Config {
+        default_sched: None,
+        default_mode: Some(SchedMode::Auto),
+        scheds: HashMap::from([
+            ("scx_bpfland".to_string(), get_default_sched_for_config(&SupportedSched::Bpfland)),
+            ("scx_rusty".to_string(), get_default_sched_for_config(&SupportedSched::Rusty)),
+            ("scx_lavd".to_string(), get_default_sched_for_config(&SupportedSched::Lavd)),
+        ]),
+    }
+}
+
+/// Get the scx flags for the given sched mode
+pub fn get_scx_flags_for_mode(
+    config: &Config,
+    scx_sched: &SupportedSched,
+    sched_mode: SchedMode,
+) -> Vec<String> {
+    if let Some(sched_config) = config.scheds.get(get_name_from_scx(scx_sched)) {
+        let scx_flags = extract_scx_flags_from_config(sched_config, &sched_mode);
+
+        // try to exact flags from config, otherwise fallback to hardcoded default
+        scx_flags.unwrap_or({
+            get_default_scx_flags_for_mode(scx_sched, sched_mode)
+                .into_iter()
+                .map(String::from)
+                .collect()
+        })
+    } else {
+        get_default_scx_flags_for_mode(scx_sched, sched_mode)
+            .into_iter()
+            .map(String::from)
+            .collect()
+    }
+}
+
+/// Extract the scx flags from config
+fn extract_scx_flags_from_config(
+    sched_config: &Sched,
+    sched_mode: &SchedMode,
+) -> Option<Vec<String>> {
+    match sched_mode {
+        SchedMode::Gaming => sched_config.gaming_mode.clone(),
+        SchedMode::LowLatency => sched_config.lowlatency_mode.clone(),
+        SchedMode::PowerSave => sched_config.powersave_mode.clone(),
+        SchedMode::Auto => sched_config.auto_mode.clone(),
+    }
+}
+
+/// Get Sched object for configuration object
+fn get_default_sched_for_config(scx_sched: &SupportedSched) -> Sched {
+    Sched {
+        auto_mode: Some(
+            get_default_scx_flags_for_mode(scx_sched, SchedMode::Auto)
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        ),
+        gaming_mode: Some(
+            get_default_scx_flags_for_mode(scx_sched, SchedMode::Gaming)
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        ),
+        lowlatency_mode: Some(
+            get_default_scx_flags_for_mode(scx_sched, SchedMode::LowLatency)
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        ),
+        powersave_mode: Some(
+            get_default_scx_flags_for_mode(scx_sched, SchedMode::PowerSave)
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        ),
+    }
+}
+
+/// Get the default scx flags for the given sched mode
+fn get_default_scx_flags_for_mode(scx_sched: &SupportedSched, sched_mode: SchedMode) -> Vec<&str> {
+    match scx_sched {
+        SupportedSched::Bpfland => match sched_mode {
+            SchedMode::Gaming => vec!["-m", "performance"],
+            SchedMode::LowLatency => vec!["-k", "-s", "5000", "-l", "5000"],
+            SchedMode::PowerSave => vec!["-m", "powersave"],
+            SchedMode::Auto => vec![],
+        },
+        SupportedSched::Lavd => match sched_mode {
+            SchedMode::Gaming | SchedMode::LowLatency => vec!["--performance"],
+            SchedMode::PowerSave => vec!["--powersave"],
+            // NOTE: potentially adding --auto in future
+            SchedMode::Auto => vec![],
+        },
+        // scx_rusty doesn't support any of these modes
+        SupportedSched::Rusty => vec![],
+    }
+}
+
+/// Get the scx trait from the given scx name or return error if the given scx name is not supported
+fn get_scx_from_str(scx_name: &str) -> Result<SupportedSched> {
+    match scx_name {
+        "scx_bpfland" => Ok(SupportedSched::Bpfland),
+        "scx_rusty" => Ok(SupportedSched::Rusty),
+        "scx_lavd" => Ok(SupportedSched::Lavd),
+        _ => Err(anyhow::anyhow!("{scx_name} is not supported")),
+    }
+}
+
+/// Get the scx name from the given scx trait
+fn get_name_from_scx(supported_sched: &SupportedSched) -> &'static str {
+    match supported_sched {
+        SupportedSched::Bpfland => "scx_bpfland",
+        SupportedSched::Rusty => "scx_rusty",
+        SupportedSched::Lavd => "scx_lavd",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::scx_loader_config::*;
+
+    #[test]
+    fn test_default_config() {
+        let config_str = r#"
+default_mode = "Auto"
+
+[scheds.scx_bpfland]
+auto_mode = []
+gaming_mode = ["-m", "performance"]
+lowlatency_mode = ["-k", "-s", "5000", "-l", "5000"]
+powersave_mode = ["-m", "powersave"]
+
+[scheds.scx_rusty]
+auto_mode = []
+gaming_mode = []
+lowlatency_mode = []
+powersave_mode = []
+
+[scheds.scx_lavd]
+auto_mode = []
+gaming_mode = ["--performance"]
+lowlatency_mode = ["--performance"]
+powersave_mode = ["--powersave"]
+"#;
+
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+        let expected_config = get_default_config();
+
+        assert_eq!(parsed_config, expected_config);
+    }
+
+    #[test]
+    fn test_simple_fallback_config_flags() {
+        let config_str = r#"
+default_mode = "Auto"
+"#;
+
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        let bpfland_flags =
+            get_scx_flags_for_mode(&parsed_config, &SupportedSched::Bpfland, SchedMode::Gaming);
+        let expected_flags =
+            get_default_scx_flags_for_mode(&SupportedSched::Bpfland, SchedMode::Gaming);
+        assert_eq!(bpfland_flags.iter().map(|x| x.as_str()).collect::<Vec<&str>>(), expected_flags);
+    }
+
+    #[test]
+    fn test_sched_fallback_config_flags() {
+        let config_str = r#"
+default_mode = "Auto"
+
+[scheds.scx_lavd]
+auto_mode = ["--help"]
+"#;
+
+        let parsed_config = parse_config_content(config_str).expect("Failed to parse config");
+
+        let lavd_flags =
+            get_scx_flags_for_mode(&parsed_config, &SupportedSched::Lavd, SchedMode::Gaming);
+        let expected_flags =
+            get_default_scx_flags_for_mode(&SupportedSched::Lavd, SchedMode::Gaming);
+        assert_eq!(lavd_flags.iter().map(|x| x.as_str()).collect::<Vec<&str>>(), expected_flags);
+
+        let lavd_flags =
+            get_scx_flags_for_mode(&parsed_config, &SupportedSched::Lavd, SchedMode::Auto);
+        assert_eq!(lavd_flags.iter().map(|x| x.as_str()).collect::<Vec<&str>>(), vec!["--help"]);
+    }
+
+    #[test]
+    fn test_empty_config() {
+        let config_str = "";
+        let result = parse_config_content(config_str);
+        assert!(result.is_err());
+    }
+}

--- a/src/conf-window.cpp
+++ b/src/conf-window.cpp
@@ -212,7 +212,6 @@ auto get_pkgext_value_from_makepkgconf() noexcept -> std::string {
     return pkgext_val;
 }
 
-
 auto prepare_func_names(std::vector<std::string> parse_lines, std::string_view pkgver_str) noexcept -> std::vector<std::string> {
     using namespace std::string_view_literals;
 

--- a/src/schedext-window.hpp
+++ b/src/schedext-window.hpp
@@ -39,6 +39,8 @@
 
 #include <ui_schedext-window.h>
 
+#include "scx_utils.hpp"
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -68,6 +70,8 @@ class SchedExtWindow final : public QMainWindow {
     void on_disable() noexcept;
     void on_sched_changed() noexcept;
 
+    const std::string_view m_config_path{"/etc/scx_loader.toml"};
+    scx::loader::ConfigPtr m_scx_config;
     std::vector<std::string> m_previously_set_options{};
     std::unique_ptr<Ui::SchedExtWindow> m_ui = std::make_unique<Ui::SchedExtWindow>();
     QTimer* m_sched_timer                    = nullptr;

--- a/src/scx_utils.cpp
+++ b/src/scx_utils.cpp
@@ -1,0 +1,168 @@
+// Copyright (C) 2024 Vladislav Nepogodin
+//
+// This file is part of CachyOS kernel manager.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#include "scx_utils.hpp"
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wdeprecated-this-capture"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QDBusVariant>
+
+#include "config-option-lib-cxxbridge/scx_loader_config.h"
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+#include <fmt/core.h>
+
+namespace {
+
+auto convert_rust_vec_string(auto&& rust_vec) -> std::vector<std::string> {
+    std::vector<std::string> res_vec{};
+    res_vec.reserve(rust_vec.size());
+    for (auto&& rust_vec_el : rust_vec) {
+        res_vec.emplace_back(std::string{rust_vec_el});
+    }
+    return res_vec;
+}
+
+auto convert_std_vec_into_stringlist(std::vector<std::string>&& std_vec) -> QStringList {
+    QStringList flags;
+    flags.reserve(static_cast<qsizetype>(std_vec.size()));
+    for (auto&& vec_el : std_vec) {
+        flags << QString::fromStdString(vec_el);
+    }
+    return flags;
+}
+
+}  // namespace
+
+namespace scx::loader {
+
+auto get_supported_scheds() noexcept -> std::optional<QStringList> {
+    QDBusMessage message = QDBusMessage::createMethodCall(
+        "org.scx.Loader",
+        "/org/scx/Loader",
+        "org.freedesktop.DBus.Properties",
+        "Get");
+    message << "org.scx.Loader" << "SupportedSchedulers";
+    QDBusMessage reply = QDBusConnection::systemBus().call(message);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        fmt::print(stderr, "Failed to get supported schedulers: {}\n", reply.errorMessage().toStdString());
+        return std::nullopt;
+    }
+
+    return reply.arguments().at(0).value<QDBusVariant>().variant().toStringList();
+}
+
+auto get_current_scheduler() noexcept -> std::optional<QString> {
+    QDBusMessage message = QDBusMessage::createMethodCall(
+        "org.scx.Loader",
+        "/org/scx/Loader",
+        "org.freedesktop.DBus.Properties",
+        "Get");
+    message << "org.scx.Loader" << "CurrentScheduler";
+    QDBusMessage reply = QDBusConnection::systemBus().call(message);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        fmt::print(stderr, "Failed to get current scheduler: {}\n", reply.errorMessage().toStdString());
+        return std::nullopt;
+    }
+
+    return reply.arguments().at(0).value<QDBusVariant>().variant().toString();
+}
+
+auto switch_scheduler_with_args(std::string_view scx_sched, QStringList sched_args) noexcept -> bool {
+    QDBusMessage message = QDBusMessage::createMethodCall(
+        "org.scx.Loader",
+        "/org/scx/Loader",
+        "org.scx.Loader",
+        "SwitchSchedulerWithArgs");
+    message << QString::fromStdString(std::string{scx_sched}) << sched_args;
+    QDBusMessage reply = QDBusConnection::systemBus().call(message);
+    if (reply.type() == QDBusMessage::ErrorMessage) {
+        fmt::print(stderr, "Failed to switch scheduler with args: {}\n", reply.errorMessage().toStdString());
+        return false;
+    }
+    return true;
+}
+
+auto Config::init_config(std::string_view filepath) noexcept -> std::optional<Config> {
+    try {
+        const ::rust::Str filepath_rust(filepath.data(), filepath.size());
+        auto&& config = Config(scx_loader::init_config_file(filepath_rust));
+        return std::make_optional<Config>(std::move(config));
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Failed to parse init config: {}\n", e.what());
+    }
+    return std::nullopt;
+}
+
+auto Config::scx_flags_for_mode(std::string_view scx_sched, SchedMode sched_mode) noexcept -> std::optional<QStringList> {
+    try {
+        const ::rust::Str scx_sched_rust(scx_sched.data(), scx_sched.size());
+        auto rust_vec  = m_config->get_scx_flags_for_mode(scx_sched_rust, static_cast<std::uint32_t>(sched_mode));
+        auto flags_vec = convert_rust_vec_string(std::move(rust_vec));
+        return convert_std_vec_into_stringlist(std::move(flags_vec));
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Failed to get scx flag for the mode: {}\n", e.what());
+    }
+    return std::nullopt;
+}
+
+auto Config::set_scx_sched_with_mode(std::string_view scx_sched, SchedMode sched_mode) noexcept -> bool {
+    try {
+        const ::rust::Str scx_sched_rust(scx_sched.data(), scx_sched.size());
+        m_config->set_scx_sched_with_mode(scx_sched_rust, static_cast<std::uint32_t>(sched_mode));
+        return true;
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Failed to set default scx scheduler with mode: {}\n", e.what());
+    }
+    return false;
+}
+
+auto Config::write_config_file(std::string_view filepath) noexcept -> bool {
+    try {
+        const ::rust::Str filepath_rust(filepath.data(), filepath.size());
+        m_config->write_config_file(filepath_rust);
+        return true;
+    } catch (const std::exception& e) {
+        fmt::print(stderr, "Failed to set default scx scheduler with mode: {}\n", e.what());
+    }
+    return false;
+}
+
+}  // namespace scx::loader

--- a/src/scx_utils.hpp
+++ b/src/scx_utils.hpp
@@ -1,0 +1,116 @@
+// Copyright (C) 2024 Vladislav Nepogodin
+//
+// This file is part of CachyOS kernel manager.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+#ifndef SCX_UTILS_HPP
+#define SCX_UTILS_HPP
+
+#include <optional>
+#include <string_view>
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+#pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wdeprecated-this-capture"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnull-dereference"
+#pragma GCC diagnostic ignored "-Wuseless-cast"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wsuggest-final-types"
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=pure"
+#pragma GCC diagnostic ignored "-Wconversion"
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+
+#include <QStringList>
+
+#include "rust/cxx.h"
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+namespace scx_loader {
+struct Config;
+}
+
+namespace scx {
+
+enum class SchedMode : std::uint8_t {
+    /// Default values for the scheduler
+    Auto = 0,
+    /// Applies flags for better gaming experience
+    Gaming = 1,
+    /// Applies flags for lower power usage
+    PowerSave = 2,
+    /// Starts scheduler in low latency mode
+    LowLatency = 3,
+};
+
+}  // namespace scx
+
+namespace scx::loader {
+
+// Gets supported schedulers by scx_loader
+auto get_supported_scheds() noexcept -> std::optional<QStringList>;
+
+// Gets currently running scheduler by scx_loader
+auto get_current_scheduler() noexcept -> std::optional<QString>;
+
+// Switches scheduler with specified args
+auto switch_scheduler_with_args(std::string_view scx_sched, QStringList sched_args) noexcept -> bool;
+
+/// @brief Manages configuration of scx_loader.
+///
+/// This structure holds pointer to object from Rust code, which represents
+/// the actual Config structure.
+class Config {
+ public:
+    /// @brief Initializes config from config path, if the file
+    /// doesn't exist config with default values will be created.
+    static auto init_config(std::string_view filepath) noexcept -> std::optional<Config>;
+
+    /// @brief Writes the config to the file.
+    auto write_config_file(std::string_view filepath) noexcept -> bool;
+
+    /// @brief Returns the scx flags for the given sched mode.
+    auto scx_flags_for_mode(std::string_view scx_sched, SchedMode sched_mode) noexcept -> std::optional<QStringList>;
+
+    /// @brief Sets the default scheduler with default mode.
+    auto set_scx_sched_with_mode(std::string_view scx_sched, SchedMode sched_mode) noexcept -> bool;
+
+    // explicitly deleted
+    Config() = delete;
+
+ private:
+    explicit Config(::rust::Box<::scx_loader::Config>&& config) : m_config(std::move(config)) { }
+
+    /// @brief A pointer to the Config structure from Rust code.
+    ::rust::Box<::scx_loader::Config> m_config;
+};
+
+/// @brief A unique pointer to a Config object.
+using ConfigPtr = std::unique_ptr<Config>;
+
+}  // namespace scx::loader
+
+#endif  // SCX_UTILS_HPP


### PR DESCRIPTION
Take into consideration the scx_loader configuration: Load the configuration or use default values if it is not present. Following this, the user has the option to manually edit the configuration file using their preferred text editor.

If the scx.service is currently running or enabled, disable it to avoid any potential conflicts with scx_loader.