### PR TITLE
terminal-helper: add support for ghostty

### DIFF
--- a/src/terminal-helper
+++ b/src/terminal-helper
@@ -56,8 +56,9 @@ declare -A terminals=(
     ["st"]="st $cmd"
     ["foot"]="foot $cmd"
     ["rio"]="rio -e $cmd"
+    ["ghostty"]="ghostty -e $cmd"
 )
-declare -a term_order=("alacritty" "kitty" "ptyxis" "konsole" "kgx" "gnome-terminal" "xfce4-terminal" "lxterminal" "xterm" "st" "foot" "rio")
+declare -a term_order=("alacritty" "kitty" "ptyxis" "konsole" "kgx" "gnome-terminal" "xfce4-terminal" "lxterminal" "xterm" "st" "foot" "rio" "ghostty")
 
 if [ -z "$terminal" ] || ! command -v "$terminal" &> /dev/null; then
 for entry in ${term_order[@]}; do


### PR DESCRIPTION
I use ghostty and the kernel manager was giving me an error that I have no terminal installed. I think this is the right place to fix this.