### PR TITLE
i18n: add Dutch (nl_NL) translation

### DIFF
--- a/cachyoskm_locale.qrc
+++ b/cachyoskm_locale.qrc
@@ -10,5 +10,6 @@
         <file alias="sk">lang/cachyos-kernel-manager_sk.qm</file>
         <file alias="sv">lang/cachyos-kernel-manager_sv.qm</file>
         <file alias="tr">lang/cachyos-kernel-manager_tr.qm</file>
+        <file alias="nl">lang/cachyos-kernel-manager_nl.qm</file>
     </qresource>
 </RCC>

--- a/lang/cachyos-kernel-manager_nl.ts
+++ b/lang/cachyos-kernel-manager_nl.ts
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl_NL">
+<context>
+    <name>ConfOptionsPage</name>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="66"/>
+        <source>Enable CachyOS config</source>
+        <translation>CachyOS-configuratie inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="95"/>
+        <source>Tweak kernel options prior to a build via nconfig</source>
+        <translation>Kernelopties aanpassen vóór de build via nconfig</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="153"/>
+        <source>Tweak kernel options prior to a build via xconfig</source>
+        <translation>Kernelopties aanpassen vóór de build via xconfig</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="240"/>
+        <source>Use Modprobed-db</source>
+        <translation>Gebruik Modprobed-db</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="269"/>
+        <source>Enable KBUILD_CFLAGS -O3</source>
+        <translation>KBUILD_CFLAGS -O3 inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="298"/>
+        <source>Set performance governor as default</source>
+        <translation>Stel de prestatie-governor in als standaard</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="327"/>
+        <source>Enable TCP_CONG_BBR3</source>
+        <translation>TCP_CONG_BBR3 inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="356"/>
+        <source>Running tick rate</source>
+        <translation>Lopende tickfrequentie</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="385"/>
+        <source>Select tickless</source>
+        <translation>Tickless selecteren</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="414"/>
+        <source>Select preempt</source>
+        <translation>Preempt selecteren</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="443"/>
+        <source>Transparent Hugepages</source>
+        <translation>Transparent Hugepages instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="472"/>
+        <source>Enable DAMON</source>
+        <translation>DAMON inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="501"/>
+        <source>CPU compiler optimizations</source>
+        <translation>CPU-compileroptimalisaties</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="530"/>
+        <source>Apply automatic CPU Optimization</source>
+        <translation>Automatische CPU-optimalisatie toepassen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="559"/>
+        <source>Enable LTO</source>
+        <translation>LTO inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="588"/>
+        <source>Build the ZFS module</source>
+        <translation>ZFS-module bouwen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="617"/>
+        <source>Build the NVIDIA module</source>
+        <translation>NVIDIA-module bouwen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="646"/>
+        <source>Build the open NVIDIA module</source>
+        <translation>Open NVIDIA-module bouwen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="675"/>
+        <source>Include vmlinux with debug informations/symbols</source>
+        <translation>vmlinux opnemen met debug-informatie/symbolen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="721"/>
+        <source>Load</source>
+        <translation>Laden</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="728"/>
+        <source>Save</source>
+        <translation>Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="748"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="755"/>
+        <source>Build kernel</source>
+        <translation>Kernel bouwen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="33"/>
+        <source>Custom package name</source>
+        <translation>Aangepaste pakketnaam</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="53"/>
+        <source>$pkgbase</source>
+        <translation>$pkgbase</translation>
+    </message>
+</context>
+
+<context>
+    <name>ConfPatchesPage</name>
+    <message>
+        <location filename="../src/conf-patches-page.ui" line="81"/>
+        <source>Add remote patch</source>
+        <translation>Externe patch toevoegen</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-patches-page.ui" line="88"/>
+        <source>Add local patch</source>
+        <translation>Lokale patch toevoegen</translation>
+    </message>
+</context>
+
+<context>
+    <name>ConfWindow</name>
+    <message>
+        <location filename="../src/conf-window.ui" line="17"/>
+        <source>CachyOS Kernel Manager Configure</source>
+        <translation>CachyOS Kernel Manager configureren</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.ui" line="40"/>
+        <source>Options</source>
+        <translation>Opties</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.ui" line="45"/>
+        <source>Patches</source>
+        <translation>Patches</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="370"/>
+        <source>Do you want to install build packages?</source>
+        <translation>Wilt u de gebouwde pakketten installeren?</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="482"/>
+        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <translation>CachyOS-standaardplanner (BORE+Cachy Sauce)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="483"/>
+        <source>BORE - Burst-Oriented Response Enhancer</source>
+        <translation>BORE - Burst-Oriented Response Enhancer</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="484"/>
+        <source>RC - Release Candidate</source>
+        <translation>RC - Release Candidate</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="485"/>
+        <source>RT - Realtime kernel</source>
+        <translation>RT - Realtime kernel</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="486"/>
+        <source>RT-Bore</source>
+        <translation>RT-Bore</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="487"/>
+        <source>EEVDF</source>
+        <translation>EEVDF</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="488"/>
+        <source>BMQ (BitMap Queue)</source>
+        <translation>BMQ (BitMap Queue)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="563"/>
+        <source>Select one or more patch files</source>
+        <translation>Selecteer een of meer patch-bestanden</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="565"/>
+        <source>Patch file (*.patch)</source>
+        <translation>Patch-bestand (*.patch)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="585"/>
+        <source>Enter URL patch</source>
+        <translation>Patch-URL invoeren</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="586"/>
+        <source>Patch URL:</source>
+        <translation>Patch-URL:</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="709"/>
+        <source>Save file as</source>
+        <translation>Opslaan als</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="711"/>
+        <location filename="../src/conf-window.cpp" line="728"/>
+        <source>Config file (*.toml)</source>
+        <translation>Configuratiebestand (*.toml)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="718"/>
+        <source>Failed to save config options to file: %1</source>
+        <translation>Opslaan van configuratieopties naar bestand mislukt: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="726"/>
+        <source>Load from</source>
+        <translation>Laden van</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="736"/>
+        <source>Failed to load config options from file: %1</source>
+        <translation>Kon configuratieopties niet laden uit bestand: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="772"/>
+        <source>Config file(%1) is outdated</source>
+        <translation>Configuratiebestand (%1) is verouderd</translation>
+    </message>
+</context>
+
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/km-window.ui" line="17"/>
+        <source>CachyOS Kernel Manager</source>
+        <translation>CachyOS Kernel Manager</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="64"/>
+        <source>Choose</source>
+        <translation>Selecteren</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="69"/>
+        <source>PkgName</source>
+        <translation>Pakketnaam</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="74"/>
+        <source>Version</source>
+        <translation>Versie</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="79"/>
+        <source>Category</source>
+        <translation>Categorie</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="116"/>
+        <source>sched-ext scheduler config</source>
+        <translation>sched-ext plannerconfiguratie</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="123"/>
+        <source>Configure</source>
+        <translation>Configureren</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="130"/>
+        <source>Cancel</source>
+        <translation>Annuleren</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="137"/>
+        <source>Execute</source>
+        <translation>Uitvoeren</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="227"/>
+        <source>No kernels found!
+Please run `pacman -Sy` to update DB!
+This is needed for the app to work properly</source>
+        <translation>Geen kernels gevonden!
+Voer `pacman -Sy` uit om de database bij te werken!
+Dit is nodig om de applicatie correct te laten werken</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Added complete Dutch translation file (`cachyos-kernel-manager_nl.ts`).