### PR TITLE
kernel-manager: Remove build_nvidia and update default kernel name

### DIFF
--- a/config-option-lib/src/lib.rs
+++ b/config-option-lib/src/lib.rs
@@ -35,7 +35,6 @@ mod ffi {
         pub localmodcfg_check: bool,
         pub use_current_check: bool,
         pub builtin_zfs_check: bool,
-        pub builtin_nvidia_check: bool,
         pub builtin_nvidia_open_check: bool,
         pub build_debug_check: bool,
 

--- a/lang/cachyos-kernel-manager_ca.ts
+++ b/lang/cachyos-kernel-manager_ca.ts
@@ -150,11 +150,6 @@
         <source>$pkgbase</source>
         <translation>$pkgbase</translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>Construeix el mòdul d&apos;NVIDIA</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -268,7 +263,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_cs.ts
+++ b/lang/cachyos-kernel-manager_cs.ts
@@ -140,11 +140,6 @@
         <source>$pkgbase</source>
         <translation>$pkgbase</translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>Vytvořit modul NVIDIA</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -258,7 +253,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_de.ts
+++ b/lang/cachyos-kernel-manager_de.ts
@@ -135,11 +135,6 @@
         <source>$pkgbase</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>NVIDIA Module kompilieren</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -249,7 +244,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_ko.ts
+++ b/lang/cachyos-kernel-manager_ko.ts
@@ -135,11 +135,6 @@
         <source>$pkgbase</source>
         <translation>$pkgbase</translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>NVIDIA 모듈 빌드</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -249,7 +244,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation>CachyOS 기본 스케줄러 (BORE+Cachy Sauce)</translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_nl.ts
+++ b/lang/cachyos-kernel-manager_nl.ts
@@ -84,11 +84,6 @@
         <translation>ZFS-module bouwen</translation>
     </message>
     <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>NVIDIA-module bouwen</translation>
-    </message>
-    <message>
         <location filename="../src/conf-options-page.ui" line="646"/>
         <source>Build the open NVIDIA module</source>
         <translation>Open NVIDIA-module bouwen</translation>
@@ -168,7 +163,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation>CachyOS-standaardplanner (BORE+Cachy Sauce)</translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_pl.ts
+++ b/lang/cachyos-kernel-manager_pl.ts
@@ -135,11 +135,6 @@
         <source>$pkgbase</source>
         <translation>$pkgbase</translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>Zbuduj moduł NVIDIA</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -253,7 +248,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_ru.ts
+++ b/lang/cachyos-kernel-manager_ru.ts
@@ -122,11 +122,6 @@
         <translation>Собрать модуль ZFS</translation>
     </message>
     <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>Собрать модуль NVIDIA</translation>
-    </message>
-    <message>
         <location filename="../src/conf-options-page.ui" line="675"/>
         <source>Include vmlinux with debug informations/symbols</source>
         <translation>Включить vmlinux с отладочной информацией/символами</translation>
@@ -193,7 +188,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_sk.ts
+++ b/lang/cachyos-kernel-manager_sk.ts
@@ -135,11 +135,6 @@
         <source>$pkgbase</source>
         <translation>$pkgbase</translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>Vytvoriť modul NVIDIA</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -253,7 +248,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_sv.ts
+++ b/lang/cachyos-kernel-manager_sv.ts
@@ -117,11 +117,6 @@
         <translation>Bygg ZFS-modulen</translation>
     </message>
     <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>Bygg NVIDIA-modulen</translation>
-    </message>
-    <message>
         <location filename="../src/conf-options-page.ui" line="646"/>
         <source>Build the open NVIDIA module</source>
         <translation>Bygg den öppna NVIDIA-modulen</translation>
@@ -189,7 +184,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation>CachyOS standardschemaläggare (BORE+Cachy Sauce)</translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_tr.ts
+++ b/lang/cachyos-kernel-manager_tr.ts
@@ -140,11 +140,6 @@
         <source>$pkgbase</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../src/conf-options-page.ui" line="617"/>
-        <source>Build the NVIDIA module</source>
-        <translation>NVIDIA modülünü yapılandır</translation>
-    </message>
 </context>
 <context>
     <name>ConfPatchesPage</name>
@@ -258,7 +253,7 @@
     </message>
     <message>
         <location filename="../src/conf-window.cpp" line="482"/>
-        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <source>CachyOS default Scheduler (tuned EEVDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/compile_options.json
+++ b/src/compile_options.json
@@ -15,7 +15,6 @@
         "cpu_opt": "_processor_opt",
         "lto": "_use_llvm_lto",
         "builtin_zfs": "_build_zfs",
-        "builtin_nvidia": "_build_nvidia",
         "builtin_nvidia_open": "_build_nvidia_open",
         "build_debug": "_build_debug"
     }

--- a/src/conf-options-page.ui
+++ b/src/conf-options-page.ui
@@ -493,35 +493,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QWidget" name="builtin_nvidia_widget" native="true">
-          <layout class="QHBoxLayout" name="builtin_nvidia_horizontal_layout">
-           <item>
-            <widget class="QLabel" name="builtin_nvidia_label">
-             <property name="text">
-              <string>Build the NVIDIA module</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="builtin_nvidia_horizontal_spacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="builtin_nvidia_check"/>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
          <widget class="QWidget" name="builtin_nvidia_open_widget" native="true">
           <layout class="QHBoxLayout" name="builtin_nvidia_open_horizontal_layout">
            <item>

--- a/src/conf-window.cpp
+++ b/src/conf-window.cpp
@@ -380,7 +380,6 @@ void ConfWindow::connect_all_checkboxes() noexcept {
     auto* options_page_ui_obj = m_ui->conf_options_page_widget->get_ui_obj();
 
     const std::array checkbox_list{
-        options_page_ui_obj->builtin_nvidia_check,
         options_page_ui_obj->builtin_nvidia_open_check,
     };
 
@@ -408,7 +407,6 @@ std::string ConfWindow::get_all_set_values() const noexcept {
     result += convert_to_var_assign_empty_wrapped("localmodcfg", checkstate_checked(options_page_ui_obj->localmodcfg_check));
     result += convert_to_var_assign_empty_wrapped("use_current", checkstate_checked(options_page_ui_obj->use_current_check));
     result += convert_to_var_assign_empty_wrapped("builtin_zfs", checkstate_checked(options_page_ui_obj->builtin_zfs_check));
-    result += convert_to_var_assign_empty_wrapped("builtin_nvidia", checkstate_checked(options_page_ui_obj->builtin_nvidia_check));
     result += convert_to_var_assign_empty_wrapped("builtin_nvidia_open", checkstate_checked(options_page_ui_obj->builtin_nvidia_open_check));
     result += convert_to_var_assign_empty_wrapped("build_debug", checkstate_checked(options_page_ui_obj->build_debug_check));
 
@@ -467,7 +465,7 @@ ConfWindow::ConfWindow(QWidget* parent)
 
     // Selecting the CPU scheduler
     QStringList kernel_names;
-    kernel_names << tr("CachyOS default scheduler (BORE+Cachy Sauce)")
+    kernel_names << tr("CachyOS default Scheduler (tuned EEVDF)")
                  << tr("BORE - Burst-Oriented Response Enhancer")
                  << tr("RC - Release Candidate")
                  << tr("RT - Realtime kernel")
@@ -691,7 +689,6 @@ void ConfWindow::on_save() noexcept {
     config_options.localmodcfg_check         = checkstate_checked(options_page_ui_obj->localmodcfg_check);
     config_options.use_current_check         = checkstate_checked(options_page_ui_obj->use_current_check);
     config_options.builtin_zfs_check         = checkstate_checked(options_page_ui_obj->builtin_zfs_check);
-    config_options.builtin_nvidia_check      = checkstate_checked(options_page_ui_obj->builtin_nvidia_check);
     config_options.builtin_nvidia_open_check = checkstate_checked(options_page_ui_obj->builtin_nvidia_open_check);
     config_options.build_debug_check         = checkstate_checked(options_page_ui_obj->build_debug_check);
 
@@ -751,7 +748,6 @@ void ConfWindow::on_load() noexcept {
     set_checkstate(options_page_ui_obj->localmodcfg_check, config_options->localmodcfg_check);
     set_checkstate(options_page_ui_obj->use_current_check, config_options->use_current_check);
     set_checkstate(options_page_ui_obj->builtin_zfs_check, config_options->builtin_zfs_check);
-    set_checkstate(options_page_ui_obj->builtin_nvidia_check, config_options->builtin_nvidia_check);
     set_checkstate(options_page_ui_obj->builtin_nvidia_open_check, config_options->builtin_nvidia_open_check);
     set_checkstate(options_page_ui_obj->build_debug_check, config_options->build_debug_check);
 

--- a/src/config-options.cpp
+++ b/src/config-options.cpp
@@ -61,7 +61,6 @@ auto ConfigOptions::parse_from_file(std::string_view filepath) noexcept -> std::
         .localmodcfg_check         = rust_config_options.localmodcfg_check,
         .use_current_check         = rust_config_options.use_current_check,
         .builtin_zfs_check         = rust_config_options.builtin_zfs_check,
-        .builtin_nvidia_check      = rust_config_options.builtin_nvidia_check,
         .builtin_nvidia_open_check = rust_config_options.builtin_nvidia_open_check,
         .build_debug_check         = rust_config_options.build_debug_check,
 
@@ -89,7 +88,6 @@ auto ConfigOptions::write_config_file(const ConfigOptions& config_options, std::
         .localmodcfg_check         = config_options.localmodcfg_check,
         .use_current_check         = config_options.use_current_check,
         .builtin_zfs_check         = config_options.builtin_zfs_check,
-        .builtin_nvidia_check      = config_options.builtin_nvidia_check,
         .builtin_nvidia_open_check = config_options.builtin_nvidia_open_check,
         .build_debug_check         = config_options.build_debug_check,
 

--- a/src/config-options.hpp
+++ b/src/config-options.hpp
@@ -34,7 +34,6 @@ struct ConfigOptions {
     bool localmodcfg_check{};
     bool use_current_check{};
     bool builtin_zfs_check{};
-    bool builtin_nvidia_check{};
     bool builtin_nvidia_open_check{};
     bool build_debug_check{};
 


### PR DESCRIPTION
This PR removes the "_build_nvidia" flag, which has been deprecated since the 590 driver release.

Also, it updates the default kernel scheduler naming