### PR TITLE
kernel-manager: Change the default pkgbase to -custom 

### DIFF
--- a/lang/cachyos-kernel-manager_ca.ts
+++ b/lang/cachyos-kernel-manager_ca.ts
@@ -147,8 +147,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="617"/>

--- a/lang/cachyos-kernel-manager_cs.ts
+++ b/lang/cachyos-kernel-manager_cs.ts
@@ -137,8 +137,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="617"/>

--- a/lang/cachyos-kernel-manager_de.ts
+++ b/lang/cachyos-kernel-manager_de.ts
@@ -132,7 +132,7 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
+        <source>$pkgbase-custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_ko.ts
+++ b/lang/cachyos-kernel-manager_ko.ts
@@ -132,8 +132,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="617"/>

--- a/lang/cachyos-kernel-manager_nl.ts
+++ b/lang/cachyos-kernel-manager_nl.ts
@@ -125,8 +125,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
 </context>
 

--- a/lang/cachyos-kernel-manager_pl.ts
+++ b/lang/cachyos-kernel-manager_pl.ts
@@ -132,8 +132,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="617"/>

--- a/lang/cachyos-kernel-manager_ru.ts
+++ b/lang/cachyos-kernel-manager_ru.ts
@@ -10,7 +10,7 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
+        <source>$pkgbase-custom</source>
         <translation></translation>
     </message>
     <message>

--- a/lang/cachyos-kernel-manager_sk.ts
+++ b/lang/cachyos-kernel-manager_sk.ts
@@ -132,8 +132,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="617"/>

--- a/lang/cachyos-kernel-manager_sv.ts
+++ b/lang/cachyos-kernel-manager_sv.ts
@@ -18,8 +18,8 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
-        <translation>$pkgbase</translation>
+        <source>$pkgbase-custom</source>
+        <translation>$pkgbase-custom</translation>
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="66"/>

--- a/lang/cachyos-kernel-manager_tr.ts
+++ b/lang/cachyos-kernel-manager_tr.ts
@@ -137,7 +137,7 @@
     </message>
     <message>
         <location filename="../src/conf-options-page.ui" line="53"/>
-        <source>$pkgbase</source>
+        <source>$pkgbase-custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/conf-options-page.ui
+++ b/src/conf-options-page.ui
@@ -50,7 +50,7 @@
            <item>
             <widget class="QLineEdit" name="custom_name_edit">
              <property name="text">
-              <string>$pkgbase</string>
+              <string>$pkgbase-custom</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
The main benefit is here, that the user will not compile with the same name when creating an own customized kernel.
Often, it will also automatically update then again to repository version, if the pkgrel is higher.