### PR TITLE
i18n: add Japanese translation

### DIFF
--- a/cachyoskm_locale.qrc
+++ b/cachyoskm_locale.qrc
@@ -4,6 +4,7 @@
         <file alias="ca">lang/cachyos-kernel-manager_ca.qm</file>
         <file alias="cs">lang/cachyos-kernel-manager_cs.qm</file>
         <file alias="de">lang/cachyos-kernel-manager_de.qm</file>
+        <file alias="ja">lang/cachyos-kernel-manager_ja.qm</file>
         <file alias="ko">lang/cachyos-kernel-manager_ko.qm</file>
         <file alias="pl">lang/cachyos-kernel-manager_pl.qm</file>
         <file alias="ru">lang/cachyos-kernel-manager_ru.qm</file>

--- a/lang/cachyos-kernel-manager_ja.ts
+++ b/lang/cachyos-kernel-manager_ja.ts
@@ -1,0 +1,357 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja_JP">
+<context>
+    <name>ConfOptionsPage</name>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="33"/>
+        <source>Custom package name</source>
+        <translation>カスタムパッケージ名</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="53"/>
+        <source>$pkgbase</source>
+        <translation>$pkgbase</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="66"/>
+        <source>Enable CachyOS config</source>
+        <translation>CachyOS のカスタム設定を有効化</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="95"/>
+        <source>Tweak kernel options prior to a build via nconfig</source>
+        <translation>ビルド前にカーネル設定を nconfig で変更</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="124"/>
+        <source>Tweak kernel options prior to a build via xconfig</source>
+        <translation>ビルド前にカーネル設定を xconfig で変更</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="153"/>
+        <source>Use Modprobed-db</source>
+        <translation>Modprobed-db を使用</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="182"/>
+        <source>Use the current kernel&apos;s config</source>
+        <translation>現在のカーネル設定を使用</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="211"/>
+        <source>Enable KBUILD_CFLAGS -O3</source>
+        <translation>KBUILD_CFLAGS -O3 を有効化</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="240"/>
+        <source>Set performance governor as default</source>
+        <translation>パフォーマンスガバナーをデフォルトに設定</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="269"/>
+        <source>Enable TCP_CONG_BBR3</source>
+        <translation>TCP_CONG_BBR3 を有効化</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="298"/>
+        <source>Running tick rate</source>
+        <translation>ティックレート</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="327"/>
+        <source>Select tickless</source>
+        <translation>tickless 設定</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="356"/>
+        <source>Select preempt</source>
+        <translation>preempt 設定</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="385"/>
+        <source>Transparent Hugepages</source>
+        <translation>Transparent Hugepage</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="414"/>
+        <source>CPU compiler optimizations</source>
+        <translation>CPU コンパイラ最適化設定</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="443"/>
+        <source>Enable LTO</source>
+        <translation>LTO を有効化</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="472"/>
+        <source>Build the ZFS module</source>
+        <translation>ZFS モジュールをビルド</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="501"/>
+        <source>Build the NVIDIA module</source>
+        <translation>NVIDIA モジュールをビルド</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="530"/>
+        <source>Build the open NVIDIA module</source>
+        <translation>NVIDIA オープンモジュールをビルド</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="559"/>
+        <source>Include vmlinux with debug informations/symbols</source>
+        <translation>デバッグ情報・シンボルつきの vmlinux を含める</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="605"/>
+        <source>Load</source>
+        <translation>読み込み</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="612"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="632"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-options-page.ui" line="639"/>
+        <source>Build kernel</source>
+        <translation>カーネルをビルド</translation>
+    </message>
+</context>
+<context>
+    <name>ConfPatchesPage</name>
+    <message>
+        <location filename="../src/conf-patches-page.ui" line="81"/>
+        <source>Add remote patch</source>
+        <translation>リモートパッチを追加</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-patches-page.ui" line="88"/>
+        <source>Add local patch</source>
+        <translation>ローカルパッチを追加</translation>
+    </message>
+</context>
+<context>
+    <name>ConfWindow</name>
+    <message>
+        <location filename="../src/conf-window.ui" line="17"/>
+        <source>CachyOS Kernel Manager Configure</source>
+        <translation>CachyOS カーネルマネージャー設定</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.ui" line="40"/>
+        <source>Options</source>
+        <translation>オプション</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.ui" line="45"/>
+        <source>Patches</source>
+        <translation>パッチ</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="362"/>
+        <source>Do you want to install build packages?</source>
+        <translation>ビルドパッケージをインストールしますか？</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="470"/>
+        <source>CachyOS default scheduler (BORE+Cachy Sauce)</source>
+        <translation>CachyOS 標準スケジューラ (BORE+Cachy Sauce)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="471"/>
+        <source>BORE - Burst-Oriented Response Enhancer</source>
+        <translation>BORE - Burst-Oriented Response Enhancer</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="472"/>
+        <source>RC - Release Candidate</source>
+        <translation>RC - リリース候補</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="473"/>
+        <source>RT - Realtime kernel</source>
+        <translation>RT - リアルタイムカーネル</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="474"/>
+        <source>LTS - Long-term support kernel</source>
+        <translation>LTS - 長期サポートカーネル</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="475"/>
+        <source>EEVDF</source>
+        <translation>EEVDF</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="476"/>
+        <source>BMQ (BitMap Queue)</source>
+        <translation>BMQ (BitMap Queue)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="568"/>
+        <source>Select one or more patch files</source>
+        <translation>一つ以上のパッチファイルを選択</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="570"/>
+        <source>Patch file (*.patch)</source>
+        <translation>パッチファイル (*.patch)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="590"/>
+        <source>Enter URL patch</source>
+        <translation>URL パッチを入力</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="591"/>
+        <source>Patch URL:</source>
+        <translation>パッチ URL:</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="710"/>
+        <source>Save file as</source>
+        <translation>名前を付けて保存</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="712"/>
+        <location filename="../src/conf-window.cpp" line="729"/>
+        <source>Config file (*.toml)</source>
+        <translation>構成ファイル (*.toml)</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="719"/>
+        <source>Failed to save config options to file: %1</source>
+        <translation>ファイルへの構成設定の保存に失敗しました: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="727"/>
+        <source>Load from</source>
+        <translation>読み込むファイルを選択</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="737"/>
+        <source>Failed to load config options from file: %1</source>
+        <translation>ファイルからの構成設定の読み込みに失敗しました: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/conf-window.cpp" line="769"/>
+        <source>Config file(%1) is outdated</source>
+        <translation>構成ファイル(%1) が古くなっています</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/km-window.ui" line="17"/>
+        <source>CachyOS Kernel Manager</source>
+        <translation>CachyOS カーネルマネージャー</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="27"/>
+        <source>&lt;html&gt;
+&lt;body&gt;
+&lt;p&gt;Here you&apos;ll see information about currently installed and available Linux kernels.&lt;/p&gt;
+&lt;p&gt;You can install/uninstall kernel packages using the checkboxes on the leftmost column.&lt;/p&gt;
+&lt;p&gt;This app won&apos;t work if you are already running a pacman instance.&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;</source>
+        <translation>&lt;html&gt;
+&lt;body&gt;
+&lt;p&gt;ここではインストール済みおよび利用可能な Linux カーネルの情報を確認できます。&lt;/p&gt;
+&lt;p&gt;左端のチェックボックスでカーネルパッケージのインストールと削除ができます。&lt;/p&gt;
+&lt;p&gt;pacman をすでに実行中の場合、このアプリは動作しません。&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="66"/>
+        <source>Choose</source>
+        <translation>選択</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="71"/>
+        <source>PkgName</source>
+        <translation>パッケージ名</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="76"/>
+        <source>Version</source>
+        <translation>バージョン</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="81"/>
+        <source>Category</source>
+        <translation>カテゴリ</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="118"/>
+        <source>sched-ext scheduler config</source>
+        <translation>sched-ext スケジューラ設定</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="125"/>
+        <source>Configure</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="132"/>
+        <source>Cancel</source>
+        <translation>キャンセル</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.ui" line="139"/>
+        <source>Execute</source>
+        <translation>実行</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="144"/>
+        <source>Failed to initialize alpm handle (%1)</source>
+        <translation>alpm ハンドルを初期化できませんでした (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="157"/>
+        <source>Failed to release alpm handle (%1)</source>
+        <translation>alpm ハンドルを解放できませんでした (%1)</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="202"/>
+        <source>Failed to clone repository!
+Please check your internet connection and try again</source>
+        <translation>リポジトリのクローンに失敗しました。
+インターネット接続を確認してから再度実行してください</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="228"/>
+        <source>No kernels found!
+Please run `pacman -Sy` to update DB!
+This is needed for the app to work properly</source>
+        <translation>カーネルが見つかりません。
+`pacman -Sy` を実行してデータベースを更新してください。
+この作業はアプリが正常に動作するために必要です</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="277"/>
+        <location filename="../src/km-window.cpp" line="341"/>
+        <source>Please wait...
+We are preparing configuration window for you
+cloning PKGBUILDs..</source>
+        <translation>しばらくお待ちください...
+設定ウィンドウを準備しています
+PKGBUILD をクローン中..</translation>
+    </message>
+    <message>
+        <location filename="../src/km-window.cpp" line="362"/>
+        <source>Please wait...
+Initializing kernels..</source>
+        <translation>しばらくお待ちください...
+カーネルを初期化中..</translation>
+    </message>
+</context>
+</TS>

--- a/org.cachyos.KernelManager.desktop
+++ b/org.cachyos.KernelManager.desktop
@@ -2,10 +2,14 @@
 Type=Application
 Version=1.0
 Name=CachyOS Kernel Manager
+Name[ja]=CachyOS カーネルマネージャー
 GenericName=Kernel Manager
+GenericName[ja]=カーネルマネージャー
 Keywords=cachyos;system;kernel;
+Keywords[ja]=cachyos;system;kernel;システム;カーネル
 Exec=cachyos-kernel-manager
 Comment=Manage kernels
+Comment[ja]=カーネルを管理
 Icon=org.cachyos.KernelManager
 Terminal=false
 StartupNotify=false

--- a/org.cachyos.KernelManager.pkexec.policy
+++ b/org.cachyos.KernelManager.pkexec.policy
@@ -8,7 +8,9 @@
 
   <action id="org.cachyos.KernelManager.pkexec.policy.run-root-terminal">
     <description>Run kernel installation/removal</description>
+    <description xml:lang="ja">カーネルのインストール・削除を実行</description>
     <message>Authentication is required to run the installation/removal</message>
+    <message xml:lang="ja">インストール・削除の実行には認証が必要です</message>
     <icon_name>cachyos-kernel-manager</icon_name>
     <defaults>
       <allow_any>no</allow_any>


### PR DESCRIPTION
This adds lang/cachyos-kernel-manager_ja.ts, org.cachyos.KernelManager.pkexec.policy, org.cachyos.KernelManager.desktop translation.