### PR TITLE
fix: keep terminal helper script alive until child exits

### DIFF
--- a/src/terminal-helper
+++ b/src/terminal-helper
@@ -37,7 +37,10 @@ done
 shift $(($OPTIND - 1))
 
 file="$(mktemp)"
-echo "$1" > "$file"
+{
+    echo 'trap '\''status=$?; rm -f -- "$0"; exit "$status"'\'' EXIT'
+    echo "$1"
+} > "$file"
 cmd="${LAUNCHER_CMD} \"$file\""
 echo $cmd
 
@@ -77,5 +80,7 @@ if [ -z "$terminal" ]; then
     exit 1
 fi
 
-eval "${terminals[${terminal}]}" 2>/dev/null || [[ "$terminal" != "kgx" ]] && { rm "$file"; exit 2; }
-rm "$file"
+if ! eval "${terminals[${terminal}]}" 2>/dev/null; then
+    rm -f -- "$file"
+    exit 2
+fi

--- a/tests/terminal-helper_test.sh
+++ b/tests/terminal-helper_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$repo_dir/src/terminal-helper"
+rootshell="$repo_dir/src/rootshell.sh"
+test_dir="$(mktemp -d)"
+fake_bin="$test_dir/bin"
+mkdir -p "$fake_bin"
+
+cleanup() {
+    rm -rf -- "$test_dir"
+}
+trap cleanup EXIT
+
+cat > "$fake_bin/mktemp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+file="$(/usr/bin/mktemp "$@")"
+printf '%s\n' "$file" > "$TEST_DIR/mktemp-path"
+printf '%s\n' "$file"
+EOF
+
+cat > "$fake_bin/kgx" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "${@: -1}" > "$TEST_DIR/script-path"
+if [[ -f "$TEST_DIR/kgx-fails" ]]; then
+    exit 1
+fi
+exit 0
+EOF
+
+cat > "$fake_bin/pkexec" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$@" > "$TEST_DIR/pkexec-args"
+exec "$@"
+EOF
+
+chmod 755 "$fake_bin/mktemp" "$fake_bin/kgx" "$fake_bin/pkexec"
+ln -s /usr/bin/bash "$fake_bin/bash"
+ln -s /usr/bin/rm "$fake_bin/rm"
+
+run_helper() {
+    TEST_DIR="$test_dir" PATH="$fake_bin" "$@"
+}
+
+assert_script_exists() {
+    local script
+    script="$(<"$test_dir/script-path")"
+    [[ -f "$script" ]]
+    printf '%s\n' "$script"
+}
+
+marker="$test_dir/marker"
+run_helper "$helper" "printf '%s\\n' direct-marker > '$marker'"
+script="$(assert_script_exists)"
+bash "$script"
+[[ "$(<"$marker")" == direct-marker ]]
+[[ ! -e "$script" ]]
+
+run_helper "$helper" -s "pkexec $rootshell" "printf '%s\\n' pkexec-marker > '$marker'"
+script="$(assert_script_exists)"
+run_helper pkexec "$rootshell" "$script"
+[[ "$(<"$marker")" == pkexec-marker ]]
+[[ ! -e "$script" ]]
+[[ "$(sed -n '1p' "$test_dir/pkexec-args")" == "$rootshell" ]]
+
+run_helper "$helper" "false; exit 7"
+script="$(assert_script_exists)"
+if bash "$script"; then
+    echo "expected child command failure" >&2
+    exit 1
+fi
+[[ ! -e "$script" ]]
+
+touch "$test_dir/kgx-fails"
+if run_helper "$helper" "printf '%s\\n' should-not-run > '$marker'"; then
+    echo "expected terminal launch failure" >&2
+    exit 1
+fi
+script="$(<"$test_dir/script-path")"
+[[ ! -e "$script" ]]
+[[ "$(<"$marker")" == pkexec-marker ]]
+
+echo "terminal-helper regression tests passed"


### PR DESCRIPTION
`terminal-helper` currently deletes the generated temporary script after the terminal launcher returns. However, `kgx --wait` does not guarantee that the child has already consumed the script, so the command can fail before `pkexec`/bash opens it.

This change:

- moves normal cleanup ownership into the generated script with an `EXIT` trap that preserves the child exit status;
- keeps launch-failure cleanup parent-owned;
- leaves terminal selection, the `pkexec` flow, and package/kernel command construction unchanged;
- adds a deterministic regression test covering delayed child startup, the `rootshell.sh`/`pkexec` path, non-zero child exit, and terminal launch failure.

Validation:

- `bash -n src/terminal-helper src/rootshell.sh tests/terminal-helper_test.sh`
- `tests/terminal-helper_test.sh`
- `git diff --check`

The tests use harmless marker commands only; no real package, kernel, or root operation is needed.

Fixes #87
