### PR TITLE
terminal-helper: remove scripts after execution

### DIFF
--- a/src/terminal-helper
+++ b/src/terminal-helper
@@ -37,7 +37,7 @@ done
 shift $(($OPTIND - 1))
 
 file="$(mktemp)"
-echo "$1" > "$file"
+printf '%s\n' "$1" > "$file"
 cmd="${LAUNCHER_CMD} \"$file\""
 echo $cmd
 
@@ -77,5 +77,8 @@ if [ -z "$terminal" ]; then
     exit 1
 fi
 
-eval "${terminals[${terminal}]}" 2>/dev/null || [[ "$terminal" != "kgx" ]] && { rm "$file"; exit 2; }
-rm "$file"
+printf 'rm -f -- %q\n' "$file" >> "$file"
+if ! eval "${terminals[${terminal}]}" 2>/dev/null && [[ "$terminal" != "kgx" ]]; then
+    rm "$file"
+    exit 2
+fi

--- a/src/terminal-helper
+++ b/src/terminal-helper
@@ -77,8 +77,8 @@ if [ -z "$terminal" ]; then
     exit 1
 fi
 
-printf 'rm -f -- %q\n' "$file" >> "$file"
+printf 'rm -f -- "$0"\n' >> "$file"
 if ! eval "${terminals[${terminal}]}" 2>/dev/null && [[ "$terminal" != "kgx" ]]; then
-    rm "$file"
+    rm -f -- "$file"
     exit 2
 fi


### PR DESCRIPTION
## Summary
- keep the generated terminal script available until the shell running it completes
- move cleanup into the generated script itself
- clean up immediately only when a non-KGX terminal launcher fails to start
- fix the launcher-error conditional so a successful non-KGX launch does not trigger cleanup

This prevents `pkexec` from receiving a path that has already been removed, notably with GNOME Console (`kgx`).

Closes #87

## Validation
- `bash -n src/terminal-helper`
- exercised successful terminal execution with a mock `alacritty`; verified the command ran and its temporary script was removed afterwards
- exercised terminal-launch failure; verified exit status 2 and immediate temporary-file cleanup
- `git diff --check`